### PR TITLE
Add trailingSlash option for static output

### DIFF
--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -1,6 +1,7 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
     output: 'export',
+    trailingSlash: true,
     images: { unoptimized: true }
 }
 


### PR DESCRIPTION
The default functionality of Next.js is to export paths as html files, but this requires accessing those paths with the `.html` extension, which is not the same behavior as dev. 

The trailingSlash option creates directories with
`index.html` files instead, which is more similar to dev.