### PR TITLE
Do not update omitted fields when saving to DB

### DIFF
--- a/backend/controller/webAuthn.go
+++ b/backend/controller/webAuthn.go
@@ -70,7 +70,7 @@ func SaveDBCredential(w http.ResponseWriter, credential *webauthn2.Credential) e
 		},
 	}
 
-	result := db.DB.Save(&dbCredential)
+	result := db.DB.Updates(&dbCredential)
 	if result.Error != nil {
 		helpers.DBErrorHandling(result.Error, w)
 		return errors.New("could not save credentials")


### PR DESCRIPTION
This was causing the credentials associated with the user to have its userId set to 0, which removed the association and broke authorization (but not login).