### PR TITLE
Implement a hopefully bug fix

### DIFF
--- a/backend/controller/login.go
+++ b/backend/controller/login.go
@@ -63,7 +63,7 @@ func LoginResponse(w http.ResponseWriter, r *http.Request) {
 	sessionData := models.SessionData{}
 	result := db.DB.Where(models.SessionData{UserId: user.WebAuthnID()}).Take(&sessionData)
 	if result.Error == nil {
-		result = db.DB.Delete(&sessionData)
+		result = db.DB.Where(models.SessionData{UserId: user.WebAuthnID()}).Delete(&models.SessionData{})
 	}
 	if result.Error != nil {
 		helpers.DBErrorHandling(result.Error, w)

--- a/backend/controller/webAuthn.go
+++ b/backend/controller/webAuthn.go
@@ -132,7 +132,7 @@ func RegisterResponse(w http.ResponseWriter, r *http.Request) {
 	sessionData := models.SessionData{}
 	result := db.DB.Where(models.SessionData{UserId: user.WebAuthnID()}).Take(&sessionData)
 	if result.Error == nil {
-		result = db.DB.Delete(&sessionData)
+		result = db.DB.Where(models.SessionData{UserId: user.WebAuthnID()}).Delete(&models.SessionData{})
 	}
 	if result.Error != nil {
 		helpers.DBErrorHandling(result.Error, w)
@@ -264,12 +264,10 @@ func AuthorizeResponse(w http.ResponseWriter, r *http.Request) {
 	challenge, _ := base64.StdEncoding.DecodeString(chi.URLParam(r, "challenge"))
 
 	// Get the session data stored from the function above
-	sessionData := models.SessionData{
-		Challenge: string(challenge),
-	}
-	result := db.DB.First(&sessionData)
+	sessionData := models.SessionData{}
+	result := db.DB.Where(models.SessionData{Challenge: string(challenge)}).Take(&sessionData)
 	if result.Error == nil {
-		result = db.DB.Delete(&sessionData)
+		result = db.DB.Where(models.SessionData{Challenge: string(challenge)}).Delete(&models.SessionData{})
 	}
 	if result.Error != nil {
 		helpers.DBErrorHandling(result.Error, w)
@@ -309,8 +307,8 @@ func AuthorizeResponse(w http.ResponseWriter, r *http.Request) {
 	//	return
 	//}
 
-	cred := models.Credential{Id: credential.ID}
-	res := db.DB.First(&cred)
+	cred := models.Credential{}
+	res := db.DB.Where(models.Credential{Id: credential.ID}).Take(&cred)
 	if res.Error != nil {
 		http.Error(w, "Could retrieve credential", http.StatusInternalServerError)
 		return

--- a/frontend/src/components/buttonsRow/buttonsRow.tsx
+++ b/frontend/src/components/buttonsRow/buttonsRow.tsx
@@ -50,6 +50,7 @@ export default function ButtonRow({
       id: 1,
       name: "New User",
       onClick: async () => {
+        setDisabled(false);
         setRoles(await getRoleOptions());
         setNewUserModal(true);
       },
@@ -57,12 +58,16 @@ export default function ButtonRow({
     {
       id: 2,
       name: "New Key",
-      onClick: () => setNewKeyModal(true),
+      onClick: () => {
+        setDisabled(false);
+        setNewKeyModal(true);
+      },
     },
     {
       id: 3,
       name: "New Role",
       onClick: async () => {
+        setDisabled(false);
         setDoors(await getDoorOptions());
         setNewRoleModal(true);
       },


### PR DESCRIPTION
This might not fix the bug, but I think our system is at least more robust this way. There are legitimate cases where a user might start the login process, but if they begin the login and don't finish (ie: quit before hitting the login/auth/register response endpoint), then their session should be persisted in the backend (and that is expected). Thus, we need a way to clear out stale sessions. Having a refresh button that hits an endpoint @ABarroso647 will create to delete the entire session table is ok (we can say it's simulating a cron job). But changing the SQL query as follows is also a good step. This prevents one user from having more than one active session (which is fine), and allows us to resync their session data upon desynchronization (ie: failing to hit the `/response` endpoint):

These screenshots are from registering a new key:
Before:
![Screenshot 2024-03-14 at 5 28 28 PM](https://github.com/lynx-locks/lynx-web/assets/55325093/6241c4d3-decb-4e7b-808f-4b016742635c)

After:
![Screenshot 2024-03-14 at 5 33 27 PM](https://github.com/lynx-locks/lynx-web/assets/55325093/93dea660-ec61-4bc6-a757-32cbd9d9e63a)

As can be seen, the session is deleted by user id, meaning that if a session gets de-synced and not deleted, the user's next registration attempt might fail (by picking the wrong session), but at least both of those users sessions will get deleted (allowing their next re-attempt to succeed).

This mainly affects flows where the user is known (login & register). The auth flow should be unaffected because it indexes by challenge (and Jonah's problems were with the registration, so I think we can probably assume authorization is fine for now).

PS: I think the `ActiveTokens` table works fine since it indexes by the token id in the email, so there would only ever be 1 entry created in the `SendEmail` endpoint, and this token would only be deleted when the user successfully registers.