### PR TITLE
Mobile friendly register screen

### DIFF
--- a/frontend/src/app/register/register.module.css
+++ b/frontend/src/app/register/register.module.css
@@ -24,6 +24,12 @@
   height: 40px;
 }
 
+@media screen and (max-width: 600px) {
+  .textInput {
+    width: 80vw;
+  }
+}
+
 .textInput::placeholder {
   text-align: center;
 }


### PR DESCRIPTION
Was looking at what screens weren't compatible with mobile. Most of them are pretty good. The admin and user portal pages aren't the best but they also aren't really meant for that usage (and on a smaller screen they still look fine). So I only ended up changing the register page:

<img width="552" alt="Screenshot 2024-03-15 at 11 03 29 PM" src="https://github.com/lynx-locks/lynx-web/assets/55325093/1e0793b8-88c6-4c2e-a73d-c4a54385075a">
<img width="453" alt="Screenshot 2024-03-15 at 11 03 52 PM" src="https://github.com/lynx-locks/lynx-web/assets/55325093/8d8596a0-9269-43ce-a8c6-62ddb58f0f49">
<img width="895" alt="Screenshot 2024-03-15 at 11 01 11 PM" src="https://github.com/lynx-locks/lynx-web/assets/55325093/706ad638-39e3-4dee-a135-b8f070ab3a23">
<img width="905" alt="Screenshot 2024-03-15 at 11 02 01 PM" src="https://github.com/lynx-locks/lynx-web/assets/55325093/f0bdb4e8-3f8b-4ba0-a997-b3e1f8ee9584">
<img width="892" alt="Screenshot 2024-03-15 at 11 13 08 PM" src="https://github.com/lynx-locks/lynx-web/assets/55325093/8eed8d11-9bf5-4bf3-9bf3-c452b1d715f3">
