### PR TITLE
Redirect to requested page after login

### DIFF
--- a/backend/authMiddleware/auth.go
+++ b/backend/authMiddleware/auth.go
@@ -36,7 +36,7 @@ func VerifyAdmin(redirect bool) func(http.Handler) http.Handler {
 			if err != nil {
 				log.WithError(err).Warn("no token found")
 				if redirect {
-					http.Redirect(w, r, "/login", http.StatusSeeOther)
+					http.Redirect(w, r, "/login/?next="+r.URL.Path, http.StatusSeeOther)
 				} else {
 					http.Error(w, "no token found", http.StatusUnauthorized)
 				}
@@ -82,7 +82,7 @@ func VerifyUser(redirect bool) func(http.Handler) http.Handler {
 			if err != nil {
 				log.WithError(err).Warn("no token found")
 				if redirect {
-					http.Redirect(w, r, "/login", http.StatusSeeOther)
+					http.Redirect(w, r, "/login/?next="+r.URL.Path, http.StatusSeeOther)
 				} else {
 					http.Error(w, "no token found", http.StatusUnauthorized)
 				}
@@ -146,7 +146,7 @@ func verifySession(w http.ResponseWriter, r *http.Request, redirect bool, claims
 		log.Warn("token expired")
 		auth.ClearCookie(w)
 		if redirect {
-			http.Redirect(w, r, "/login", http.StatusSeeOther)
+			http.Redirect(w, r, "/login/?next="+r.URL.Path, http.StatusSeeOther)
 		} else {
 			http.Error(w, "token expired", http.StatusUnauthorized)
 		}

--- a/frontend/src/app/login/page.tsx
+++ b/frontend/src/app/login/page.tsx
@@ -14,7 +14,7 @@ const Login = () => {
   const [email, setEmail] = useState("");
   const searchParams = useSearchParams();
   const router = useRouter();
-  const referrer = searchParams.get("token");
+  const referrer = searchParams.get("next");
 
   const handleLogin = async () => {
     try {
@@ -45,7 +45,7 @@ const Login = () => {
             isAdmin: user.isAdmin,
           }),
         );
-        if (referrer) {
+        if (referrer && referrer !== "/") {
           router.push(referrer);
         } else if (user.isAdmin) {
           router.push("/admin/");


### PR DESCRIPTION
If you try to visit `/admin/foo` when your session is invalid, you will be redirected to `/admin/foo` after login.
If an admin initially visits `/` they will still be redirected to `/admin` after login.