### PR TITLE
Remove auth flow Search Params

### DIFF
--- a/frontend/src/app/authorize/error/page.tsx
+++ b/frontend/src/app/authorize/error/page.tsx
@@ -1,0 +1,7 @@
+import ErrorMessage from "@/components/errorMessage/errorMessage";
+
+export default function Error() {
+  return (
+    <ErrorMessage text="Error. Cannot read door identifier. Please tap your device again." />
+  );
+}

--- a/frontend/src/app/authorize/page.tsx
+++ b/frontend/src/app/authorize/page.tsx
@@ -19,18 +19,33 @@ export default function AuthorizeUser() {
     LoadingStatus.Nil,
   );
   const [authText, setAuthText] = useState<string>("Unlock");
-  const doorId = searchParams.get("doorId");
+  const [doorId, setDoorId] = useState<string | null>(null);
+
+  useEffect(() => {
+    const doorId = searchParams.get("doorId");
+    if (doorId) {
+      setDoorId(doorId);
+      router.replace("/authorize");
+    }
+  }, [router, searchParams]);
 
   useEffect(() => {
     async function getDoorName() {
-      const doorInfo = await axios.get(`auth/doors/${doorId}`);
+      const doorInfo = await axios.get(`/auth/doors/${doorId}`);
       setAuthText(`Unlock ${doorInfo.data.name}`);
     }
-    getDoorName();
-  });
+    if (doorId) {
+      getDoorName();
+    }
+  }, [doorId]);
 
   async function authorizeWithPasskey() {
     setLoadingStatus(LoadingStatus.Loading);
+
+    if (!doorId) {
+      router.replace("/authorize/error");
+      return;
+    }
 
     try {
       const resp = await axios.post(`/auth/authorize/request`);

--- a/frontend/src/components/errorMessage/errorMessage.module.css
+++ b/frontend/src/components/errorMessage/errorMessage.module.css
@@ -7,7 +7,7 @@
   border: 1px solid #f44336;
   border-radius: 8px;
   max-width: 400px;
-  margin: 0 auto;
+  margin: auto;
 }
 
 .icon {

--- a/frontend/src/components/errorMessage/errorMessage.tsx
+++ b/frontend/src/components/errorMessage/errorMessage.tsx
@@ -5,8 +5,10 @@ import LoadingStatus from "@/types/loadingStatus";
 
 export default function ErrorMessage({
   setLoadingStatus,
+  text = "Error. Something went wrong with your request. Please contact your administrator.",
 }: {
-  setLoadingStatus: Dispatch<SetStateAction<LoadingStatus>>;
+  setLoadingStatus?: Dispatch<SetStateAction<LoadingStatus>>;
+  text?: string;
 }) {
   return (
     <div className={styles.errorMessage}>
@@ -14,22 +16,21 @@ export default function ErrorMessage({
         <FaExclamationCircle size={48} color="#f44336" />
       </div>
       <div className={styles.text}>
-        <p>
-          Error. Something went wrong with your request. Please contact your
-          administrator
-        </p>
+        <p>{text}</p>
       </div>
       <div className={styles.warning}>
         <span role="img" aria-label="warning" style={{ fontSize: "24px" }}>
           ⚠️
         </span>
       </div>
-      <button
-        className={styles.tryAgainButton}
-        onClick={() => setLoadingStatus(LoadingStatus.Nil)}
-      >
-        Try Again
-      </button>
+      {setLoadingStatus && (
+        <button
+          className={styles.tryAgainButton}
+          onClick={() => setLoadingStatus(LoadingStatus.Nil)}
+        >
+          Try Again
+        </button>
+      )}
     </div>
   );
 }

--- a/frontend/src/components/successMessage/successMessage.module.css
+++ b/frontend/src/components/successMessage/successMessage.module.css
@@ -1,11 +1,5 @@
-.successMessageContainer {
-  display: flex;
-  height: 100vh;
-}
-
 .successMessage {
   display: flex;
-  flex-grow: 1;
   flex-direction: column;
   align-items: center;
   justify-content: center;

--- a/frontend/src/components/successMessage/successMessage.tsx
+++ b/frontend/src/components/successMessage/successMessage.tsx
@@ -4,19 +4,17 @@ import styles from "./successMessage.module.css";
 
 const SuccessMessage: React.FC = () => {
   return (
-    <div className={styles.successMessageContainer}>
-      <div className={styles.successMessage}>
-        <div className={styles.icon}>
-          <FaCheckCircle size={48} color="#4CAF50" />
-        </div>
-        <div className={styles.text}>
-          <p>Success! You may now close this window.</p>
-        </div>
-        <div className={styles.confetti}>
-          <span role="img" aria-label="confetti" style={{ fontSize: "24px" }}>
-            🎉
-          </span>
-        </div>
+    <div className={styles.successMessage}>
+      <div className={styles.icon}>
+        <FaCheckCircle size={48} color="#4CAF50" />
+      </div>
+      <div className={styles.text}>
+        <p>Success! You may now close this window.</p>
+      </div>
+      <div className={styles.confetti}>
+        <span role="img" aria-label="confetti" style={{ fontSize: "24px" }}>
+          🎉
+        </span>
       </div>
     </div>
   );


### PR DESCRIPTION
Since we're using static doorIds for the authorization flow, I think it's useful to try to hide them from the client as much as possible. This change loads the doorId into state and removes them from the query parameters.