### PR TITLE
Fix table sort by dates and modal overflow

### DIFF
--- a/frontend/src/components/adminTable/table.tsx
+++ b/frontend/src/components/adminTable/table.tsx
@@ -33,6 +33,19 @@ const filterUsers = (users: User[], searchInput: string) => {
   );
 };
 
+function parseTimeString(timeString: string) {
+  let [time, meridiem] = timeString.split(" ");
+  let [hours, minutes, seconds] = time.split(":").map(Number);
+
+  if (meridiem === "PM" && hours !== 12) {
+    hours += 12;
+  } else if (meridiem === "AM" && hours === 12) {
+    hours = 0;
+  }
+
+  return new Date(2000, 0, 1, hours, minutes, seconds);
+}
+
 export default function AdminTable({
   users,
   searchInput,
@@ -87,19 +100,26 @@ export default function AdminTable({
       const first = sortBy?.sort === "asc" ? a : b;
       const second = sortBy?.sort === "asc" ? b : a;
       if (sortBy?.name === "Last Time In") {
+        const mult = sortBy?.sort === "asc" ? 1 : -1;
+        if (!first.timeIn) {
+          return mult;
+        } else if (!second.timeIn) {
+          return -mult;
+        }
         return (
-          (first.timeIn &&
-            second.timeIn &&
-            first.timeIn.localeCompare(second.timeIn)) ||
-          (sortBy?.sort === "asc" ? 1 : -1)
+          parseTimeString(first.timeIn).getTime() -
+          parseTimeString(second.timeIn).getTime()
         );
       } else if (sortBy?.name === "Date") {
-        return (
-          (first.lastDateIn &&
-            second.lastDateIn &&
-            first.lastDateIn.localeCompare(second.lastDateIn)) ||
-          (sortBy?.sort === "asc" ? 1 : -1)
-        );
+        const mult = sortBy?.sort === "asc" ? 1 : -1;
+        if (!first.lastDateIn) {
+          return mult;
+        } else if (!second.lastDateIn) {
+          return -mult;
+        }
+        const firstDate = new Date(first.lastDateIn).getTime();
+        const secondDate = new Date(second.lastDateIn).getTime();
+        return firstDate - secondDate;
       } else if (sortBy?.name === "Email") {
         return first.email.localeCompare(second.email);
       } else if (sortBy?.name === "Name") {

--- a/frontend/src/components/modal/modal.module.css
+++ b/frontend/src/components/modal/modal.module.css
@@ -27,7 +27,7 @@
   width: 50%; /* Could be more or less, depending on screen size */
   min-height: 60vh;
   max-height: 80vh;
-  overflow: auto;
+  overflow: none;
   /* text-align: center; */
 }
 


### PR DESCRIPTION
- Found a couple more issues that would be nice to fix for symposium:
1. Modal overflow issue
Before:
<img width="1082" alt="Screenshot 2024-03-24 at 10 34 21 PM" src="https://github.com/lynx-locks/lynx-web/assets/55325093/c8af0689-07d7-41cf-9a1a-3b6d38d4cca9">
After:
<img width="1172" alt="Screenshot 2024-03-24 at 10 34 44 PM" src="https://github.com/lynx-locks/lynx-web/assets/55325093/e111a03d-f296-4b00-947c-6cd5b146cda7">

2. Unable to sort by date / time:

https://github.com/lynx-locks/lynx-web/assets/55325093/c94078b2-4782-48dc-9bf5-5b879e563880


https://github.com/lynx-locks/lynx-web/assets/55325093/58bc6c94-1a8c-495c-89cf-a4471da80325


